### PR TITLE
Fix typo in README: "foot" -> "sway"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Copy your theme to the sway themes folder:
 
 ```shell
 mkdir -p ~/.config/sway/themes
-cp -R "./themes/foot/THEME NAME" >> ~/.config/sway/themes
+cp -R "./themes/sway/THEME NAME" >> ~/.config/sway/themes
 ```
 
 Edit `definitions` file in theme folder and tweak theme variables (fonts and GTK, icon and cursor themes).


### PR DESCRIPTION
The README file for the project incorrectly used the word "foot" when it should have been "sway." This has been fixed.